### PR TITLE
change postinstall to prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ressendr",
   "main": "lib/index.js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "test": "node spec/runner.js",
     "work": "nodemon spec/runner.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "node spec/runner.js",
     "work": "nodemon spec/runner.js",
-    "postinstall": "babel src --out-dir lib --presets es2015"
+    "prepublish": "babel src --out-dir lib --presets es2015"
   },
   "repository": "https://github.com/scup/ResSendr",
   "dependencies": {


### PR DESCRIPTION
the lib should not depend on client babel , but use its own to checkin the bundled code